### PR TITLE
Create PersonaGraph interest-driven prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# using-codex
+# PersonaGraph
+
+PersonaGraph is a concept social network inspired by Facebook and LinkedIn that adapts itself around the interests and personality preferences you select. The prototype lives entirely in static HTML/CSS/JS so it can be opened directly in a browser.
+
+## Features
+
+- Curated feed that recombines longform stories, opportunities, and rituals from chosen interest areas.
+- Sidebars that surface suggested introductions, projects, and learning tracks matched to your interests.
+- Momentum planner that turns interests into quick actions and energy boosts.
+- Personality resonance hub that adjusts collaboration tips and conversation starters for INFJ, ENTP, INTJ, and ENFP profiles.
+
+## Getting started
+
+1. Open `index.html` in your preferred browser. No build step or backend is required.
+2. Choose the interests that align with what you want to explore to refresh the feed and supporting cards.
+3. Switch personality lenses to see how the tone and interaction tips adapt for each type.
+
+Because everything is client-side, you can deploy the folder on any static hosting platform or continue iterating locally by editing the HTML, CSS, or JavaScript files.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,1255 @@
+const interestProfiles = {
+  'AI Product Strategy': {
+    description:
+      'Translate frontier research into responsible products and rituals teams trust.',
+    highlights: [
+      'Responsible AI guardrails',
+      'Narrative-driven adoption',
+      'Experiment-to-launch loops',
+      'Outcome metrics design'
+    ],
+    feed: [
+      {
+        title: 'From prototype to responsible launch in 90 days',
+        summary:
+          'NovaNest mapped ethical guardrails into their product rituals, aligning design, science, and compliance around weekly “what could go wrong?” forums.',
+        insight:
+          'Anchor every sprint review with the user promise so emerging model behaviors stay aligned with intent.',
+        action: 'Borrow the launch readiness retro prompts to stress-test your roadmap.',
+        source: 'Catalyst Digest',
+        time: '2h ago',
+        metric: 'Signal · 92',
+        tags: ['AI strategy', 'Team rituals'],
+        score: 92
+      },
+      {
+        title: 'Narrative clarity is the real AI adoption unlock',
+        summary:
+          'Luma Systems replaced feature lists with “moment of magic” stories, helping non-technical partners grasp why the model mattered.',
+        insight:
+          'Tell the story of transformation, not technology specs—start with the before/after moment that matters to your audience.',
+        action: 'Draft a one-slide “hero moment” storyboard for your next stakeholder readout.',
+        source: 'Northstar Briefing',
+        time: '5h ago',
+        metric: 'Momentum · 88',
+        tags: ['Storytelling', 'Stakeholder enablement'],
+        score: 88
+      },
+      {
+        title: 'Operationalizing continuous model reviews',
+        summary:
+          'Beacon Labs built a shared scorecard connecting model performance to customer impact, giving teams a language for weekly course corrections.',
+        insight:
+          'Pair quantitative dashboards with lived-experience interviews to catch unintended consequences early.',
+        action: 'Schedule a listening session with a power user cohort this week.',
+        source: 'Signal Patterns',
+        time: 'Yesterday',
+        metric: 'Trust · 84',
+        tags: ['Model stewardship', 'Customer insight'],
+        score: 84
+      }
+    ],
+    momentum: [
+      {
+        title: 'Map the ethical edge cases',
+        detail: 'Invite design, legal, and a community advocate to co-create a scenario planning board.',
+        energy: '+5 clarity'
+      },
+      {
+        title: 'Storyboard a hero moment',
+        detail: 'Sketch the before/after transformation that proves value to non-technical partners.',
+        energy: '+3 alignment'
+      },
+      {
+        title: 'Run a signal sync',
+        detail: 'Review model performance with customer impact metrics in one shared ritual.',
+        energy: '+4 trust'
+      }
+    ],
+    intros: [
+      {
+        name: 'Priya Natarajan',
+        role: 'Responsible AI Lead · Luma Systems',
+        reason: 'Co-created the narrative canvas used to align executives on AI adoption stories.'
+      },
+      {
+        name: 'Miguel Reyes',
+        role: 'Product Operations Director · NovaNest',
+        reason: 'Piloted the sprint ritual that keeps AI, design, and policy in flow.'
+      },
+      {
+        name: 'Linh Dao',
+        role: 'UX Researcher · Beacon Labs',
+        reason: 'Pairs quant dashboards with lived interviews for accountable launches.'
+      }
+    ],
+    opportunities: [
+      {
+        title: 'Pilot responsible AI review council',
+        detail: 'Help a health-tech startup structure its cross-disciplinary guardrail forum.'
+      },
+      {
+        title: 'Narrative strategist-in-residence',
+        detail: 'Guide a Series B team in translating AI capabilities into business storytelling.'
+      },
+      {
+        title: 'Outcome metrics architect',
+        detail: 'Design human-centered success measures for a conversational AI platform.'
+      }
+    ],
+    learning: [
+      {
+        title: 'Designing AI guardrails workshop',
+        detail: 'Collaborative exercises to spot bias and power gaps before launch.'
+      },
+      {
+        title: 'Story-driven stakeholder decks',
+        detail: 'Learn a three-act arc to translate complex AI updates into clarity.'
+      },
+      {
+        title: 'Metrics that matter playbook',
+        detail: 'Build dashboards that connect model performance to community impact.'
+      }
+    ]
+  },
+  'Future of Work Evolution': {
+    description:
+      'Blend digital and in-person rituals that keep hybrid teams aligned and energized.',
+    highlights: [
+      'Hybrid rituals',
+      'People analytics with heart',
+      'Intentional collaboration',
+      'Adaptive policies'
+    ],
+    feed: [
+      {
+        title: 'When teams design their own hybrid agreements',
+        summary:
+          'Orbitly adopted “team operating canvases,” empowering squads to co-create cadence, availability norms, and refresh rituals.',
+        insight:
+          'Revisit norms every 6 weeks—context shifts fast and rituals should too.',
+        action: 'Send the team a pulse asking what energized them this sprint.',
+        source: 'Work Modes Weekly',
+        time: '1h ago',
+        metric: 'Flow · 90',
+        tags: ['Hybrid cadence', 'Team agreements'],
+        score: 90
+      },
+      {
+        title: 'People analytics that center belonging',
+        summary:
+          'SonderPath layered qualitative “belonging diaries” atop survey data to surface why certain rituals mattered most.',
+        insight:
+          'Pair dashboards with narrative snippets to keep humanity inside the metrics.',
+        action: 'Pilot a 3-question belonging diary with your next survey.',
+        source: 'Culture Signals',
+        time: '4h ago',
+        metric: 'Belonging · 86',
+        tags: ['People science', 'Story listening'],
+        score: 86
+      },
+      {
+        title: 'Rethinking meeting footprints',
+        summary:
+          'Atlas&Co swapped status meetings for async field reports, using live sessions for storytelling and learning labs.',
+        insight:
+          'Protect focus time by batching updates asynchronously and reserving meetings for sense-making.',
+        action: 'Record a 5-minute async field report instead of the weekly status call.',
+        source: 'Future Ops Insider',
+        time: 'Yesterday',
+        metric: 'Focus · 82',
+        tags: ['Async collaboration', 'Meeting design'],
+        score: 82
+      }
+    ],
+    momentum: [
+      {
+        title: 'Refresh the team canvas',
+        detail: 'Check if norms still serve current goals; sunset the ones draining energy.',
+        energy: '+4 alignment'
+      },
+      {
+        title: 'Pulse for belonging moments',
+        detail: 'Invite teammates to share one ritual that helps them feel seen.',
+        energy: '+3 empathy'
+      },
+      {
+        title: 'Audit meeting intent',
+        detail: 'Convert one recurring meeting into an async narrative update.',
+        energy: '+2 focus'
+      }
+    ],
+    intros: [
+      {
+        name: 'Hana Kim',
+        role: 'Head of People Experience · Orbitly',
+        reason: 'Builds co-created team agreements anchored in experimentation.'
+      },
+      {
+        name: 'Jordan Wells',
+        role: 'People Scientist · SonderPath',
+        reason: 'Transforms survey dashboards into belonging stories leadership acts on.'
+      },
+      {
+        name: 'Chaz Morgan',
+        role: 'Operations Lead · Atlas&Co',
+        reason: 'Coaches teams on async-first communication rituals.'
+      }
+    ],
+    opportunities: [
+      {
+        title: 'Hybrid operating system audit',
+        detail: 'Co-design rituals for a distributed product org scaling across time zones.'
+      },
+      {
+        title: 'Belonging analytics consultant',
+        detail: 'Translate people metrics into leadership commitments that stick.'
+      },
+      {
+        title: 'Meeting footprint redesign sprint',
+        detail: 'Lead a workshop helping teams reclaim 6 hours of focus time weekly.'
+      }
+    ],
+    learning: [
+      {
+        title: 'Designing async rituals toolkit',
+        detail: 'Templates for running narrative-rich updates without live meetings.'
+      },
+      {
+        title: 'Belonging diary research guide',
+        detail: 'Collect and synthesize qualitative insights across hybrid teams.'
+      },
+      {
+        title: 'Team operating canvas builder',
+        detail: 'Facilitated exercises to renew team agreements intentionally.'
+      }
+    ]
+  },
+  'Community Design & Belonging': {
+    description: 'Craft spaces where people feel seen, supported, and motivated to contribute.',
+    highlights: [
+      'Onboarding journeys',
+      'Belonging rituals',
+      'Story-led facilitation',
+      'Community metrics'
+    ],
+    feed: [
+      {
+        title: 'Designing belonging blueprints with members',
+        summary:
+          'The Common Thread collective co-created a belonging “north star” by mapping member stories and identifying signature moments.',
+        insight:
+          'Let members name the moments that mattered most—then build rituals around them.',
+        action: 'Host a listening salon inviting members to map their best experience.',
+        source: 'Community Craft',
+        time: '3h ago',
+        metric: 'Belonging · 89',
+        tags: ['Member research', 'Ritual design'],
+        score: 89
+      },
+      {
+        title: 'Measuring health beyond vanity metrics',
+        summary:
+          'Gather expanded their scorecard to include story submissions, mutual support threads, and peer-led experiments.',
+        insight:
+          'Focus on signals of contribution and reciprocity, not just DAU.',
+        action: 'Add one new qualitative metric to your health dashboard this month.',
+        source: 'Signal Commons',
+        time: '6h ago',
+        metric: 'Reciprocity · 83',
+        tags: ['Community analytics', 'Member-led growth'],
+        score: 83
+      },
+      {
+        title: 'Facilitation that unlocks shy voices',
+        summary:
+          'Circle Studio introduced “quiet question walls” so introverted members contribute asynchronously before gatherings.',
+        insight:
+          'Blend async prompts with live rituals so every personality can participate.',
+        action: 'Set up a voice wall before your next community gathering.',
+        source: 'Gathering Signals',
+        time: 'Yesterday',
+        metric: 'Inclusion · 81',
+        tags: ['Facilitation', 'Participation'],
+        score: 81
+      }
+    ],
+    momentum: [
+      {
+        title: 'Map signature moments',
+        detail: 'Ask members when they felt most supported and distill three rituals.',
+        energy: '+5 connection'
+      },
+      {
+        title: 'Refresh onboarding',
+        detail: 'Co-create a welcome flow with a founding member as guide.',
+        energy: '+4 belonging'
+      },
+      {
+        title: 'Invite quiet voices',
+        detail: 'Add an async reflection wall before your next live gathering.',
+        energy: '+3 inclusion'
+      }
+    ],
+    intros: [
+      {
+        name: 'Nia Holloway',
+        role: 'Community Architect · Common Thread',
+        reason: 'Designs participatory rituals rooted in member stories.'
+      },
+      {
+        name: 'Rowan Blake',
+        role: 'Insights Lead · Gather',
+        reason: 'Builds dashboards focused on reciprocity and contribution.'
+      },
+      {
+        name: 'Alma Ortiz',
+        role: 'Facilitator · Circle Studio',
+        reason: 'Blends async and live moments to welcome every personality.'
+      }
+    ],
+    opportunities: [
+      {
+        title: 'Community health diagnostic',
+        detail: 'Evaluate onboarding, rituals, and contribution loops for a new member network.'
+      },
+      {
+        title: 'Story circle facilitator',
+        detail: 'Guide monthly salons that capture member narratives and surface insights.'
+      },
+      {
+        title: 'Belonging metrics consultant',
+        detail: 'Help a community-led nonprofit define and track qualitative success.'
+      }
+    ],
+    learning: [
+      {
+        title: 'Designing signature rituals lab',
+        detail: 'Co-build rituals with members that reinforce your community promise.'
+      },
+      {
+        title: 'Facilitation for every personality',
+        detail: 'Techniques to invite reflection-first participants into conversation.'
+      },
+      {
+        title: 'Community health scorecard kit',
+        detail: 'Blend quantitative and narrative metrics into a living dashboard.'
+      }
+    ]
+  },
+  'Creative Leadership': {
+    description: 'Lead teams with imagination, clarity, and emotionally resonant storytelling.',
+    highlights: [
+      'Vision storytelling',
+      'Creative feedback',
+      'Team energy rituals',
+      'Experimentation cultures'
+    ],
+    feed: [
+      {
+        title: 'Vision memos that mobilize action',
+        summary:
+          'Brightwave leaders replaced slide decks with narrative memos outlining the emotional why, the future story, and the first experiment.',
+        insight:
+          'Stories that paint vivid futures move teams faster than bullet lists.',
+        action: 'Write a one-page vision memo before your next strategy share.',
+        source: 'Creative Ops Wire',
+        time: '45m ago',
+        metric: 'Inspiration · 93',
+        tags: ['Narrative leadership', 'Visioning'],
+        score: 93
+      },
+      {
+        title: 'Feedback that fuels possibility',
+        summary:
+          'Flux Studio introduced “feedforward labs” where teams prototype multiple options and critique the story, not the person.',
+        insight:
+          'Shift feedback from judgment to joint experimentation to protect psychological safety.',
+        action: 'Host a 30-minute feedforward lab for an upcoming concept.',
+        source: 'Studio Signals',
+        time: '3h ago',
+        metric: 'Psych safety · 87',
+        tags: ['Feedback', 'Team rituals'],
+        score: 87
+      },
+      {
+        title: 'Energy rituals for creative sprints',
+        summary:
+          'Muse Labs orchestrated focused play sessions, pairing divergent ideation with grounding reflections.',
+        insight:
+          'Creative stamina thrives on oscillating between expansion and integration.',
+        action: 'Book a micro-play session before your next brainstorm.',
+        source: 'Leadership Lab Notes',
+        time: 'Yesterday',
+        metric: 'Vitality · 84',
+        tags: ['Team energy', 'Workshop design'],
+        score: 84
+      }
+    ],
+    momentum: [
+      {
+        title: 'Write a vision memo',
+        detail: 'Share the emotional why and three experiments you want the team to try.',
+        energy: '+5 inspiration'
+      },
+      {
+        title: 'Schedule a feedforward lab',
+        detail: 'Invite cross-functional voices to remix your concept safely.',
+        energy: '+3 collaboration'
+      },
+      {
+        title: 'Design a play ritual',
+        detail: 'Add a creative warm-up to the next strategy session.',
+        energy: '+4 vitality'
+      }
+    ],
+    intros: [
+      {
+        name: 'Dev Patel',
+        role: 'Chief Storyteller · Brightwave',
+        reason: 'Turns strategies into vivid narratives teams rally behind.'
+      },
+      {
+        name: 'Mira Chen',
+        role: 'Creative Director · Flux Studio',
+        reason: 'Champions feedback labs that keep experimentation joyful.'
+      },
+      {
+        name: 'Jonas Quinn',
+        role: 'Culture Designer · Muse Labs',
+        reason: 'Builds energy rituals that sustain creative sprints.'
+      }
+    ],
+    opportunities: [
+      {
+        title: 'Narrative offsite facilitator',
+        detail: 'Help an executive team craft a story that aligns product, brand, and culture.'
+      },
+      {
+        title: 'Feedback lab coach',
+        detail: 'Teach creative orgs how to critique ideas while protecting relationships.'
+      },
+      {
+        title: 'Creative stamina consultant',
+        detail: 'Design rhythm maps balancing deep work and imaginative play.'
+      }
+    ],
+    learning: [
+      {
+        title: 'Story architecture masterclass',
+        detail: 'Blueprint compelling narratives for high-stakes leadership moments.'
+      },
+      {
+        title: 'Feedforward facilitation kit',
+        detail: 'Run critique sessions that surface better options, not defensiveness.'
+      },
+      {
+        title: 'Team energy mapping workshop',
+        detail: 'Visualize energy peaks and dips to schedule creative work intentionally.'
+      }
+    ]
+  },
+  'Climate Innovation': {
+    description:
+      'Connect climate tech breakthroughs with community-centered adoption and policy.',
+    highlights: [
+      'Carbon removal storytelling',
+      'Community pilots',
+      'Policy + product alignment',
+      'Regenerative finance'
+    ],
+    feed: [
+      {
+        title: 'Translating climate tech for local action',
+        summary:
+          'Green Horizon Labs partnered with city ambassadors to co-design micro-pilot programs before scaling infrastructure.',
+        insight:
+          'Adoption accelerates when community stewards own the pilot narrative.',
+        action: 'Recruit two local champions to narrate your next pilot.',
+        source: 'Regenerative Dispatch',
+        time: '2h ago',
+        metric: 'Adoption · 88',
+        tags: ['Community pilots', 'Climate storytelling'],
+        score: 88
+      },
+      {
+        title: 'Aligning policy windows with product roadmaps',
+        summary:
+          'TerraSync tracks regulatory calendars alongside R&D sprints to launch when momentum peaks.',
+        insight:
+          'Pair policy intelligence with product planning so you ride the right wave.',
+        action: 'Add a regulatory milestone lane to your roadmap deck.',
+        source: 'Climate Ops Weekly',
+        time: '5h ago',
+        metric: 'Timing · 84',
+        tags: ['Policy intelligence', 'Roadmap design'],
+        score: 84
+      },
+      {
+        title: 'Funding regenerative experiments responsibly',
+        summary:
+          'Riversong Collective offers community revenue-sharing models that fund pilots without extractive capital.',
+        insight:
+          'Align financing with community benefit to sustain long-term trust.',
+        action: 'Prototype a community dividend for your next funding round.',
+        source: 'Regenerative Finance Radar',
+        time: 'Yesterday',
+        metric: 'Trust · 82',
+        tags: ['Finance innovation', 'Community trust'],
+        score: 82
+      }
+    ],
+    momentum: [
+      {
+        title: 'Find a community steward',
+        detail: 'Map the people who already hold trust in your pilot region.',
+        energy: '+4 trust'
+      },
+      {
+        title: 'Sync policy & product calendars',
+        detail: 'Overlay regulatory milestones with your roadmap planning.',
+        energy: '+3 timing'
+      },
+      {
+        title: 'Design regenerative financing',
+        detail: 'Sketch a revenue share that reinvests in the host community.',
+        energy: '+4 alignment'
+      }
+    ],
+    intros: [
+      {
+        name: 'Sabine Okoye',
+        role: 'Partnerships Lead · Green Horizon Labs',
+        reason: 'Champions community-led pilots that accelerate adoption.'
+      },
+      {
+        name: 'Leo Martinez',
+        role: 'Policy Strategist · TerraSync',
+        reason: 'Keeps product roadmaps aligned with policy windows.'
+      },
+      {
+        name: 'Amina Farouk',
+        role: 'Regenerative Finance Architect · Riversong Collective',
+        reason: 'Designs funding models that reward local stewardship.'
+      }
+    ],
+    opportunities: [
+      {
+        title: 'Community pilot storyteller',
+        detail: 'Capture narratives from early adopters to unlock municipal partnerships.'
+      },
+      {
+        title: 'Policy intelligence mapper',
+        detail: 'Build a shared calendar connecting legislation to climate launches.'
+      },
+      {
+        title: 'Regenerative funding advisor',
+        detail: 'Prototype equitable revenue-sharing agreements for climate pilots.'
+      }
+    ],
+    learning: [
+      {
+        title: 'Community-centered pilot playbook',
+        detail: 'Frameworks for designing climate pilots with residents, not for them.'
+      },
+      {
+        title: 'Policy window spotting clinic',
+        detail: 'Translate regulatory momentum into product timing strategies.'
+      },
+      {
+        title: 'Regenerative finance lab',
+        detail: 'Experiment with funding models aligned to community benefit.'
+      }
+    ]
+  },
+  'Learning Science & Enablement': {
+    description:
+      'Design learning ecosystems that accelerate mastery and confidence.',
+    highlights: [
+      'Learning journeys',
+      'Enablement analytics',
+      'Community practice',
+      'Micro-coaching'
+    ],
+    feed: [
+      {
+        title: 'Designing learning journeys that stick',
+        summary:
+          'Elevate Academy layered practice arenas and peer coaching into every module, increasing applied confidence by 37%.',
+        insight:
+          'Learning lands when reflection, practice, and peer story sharing are built into the flow.',
+        action: 'Add a peer coaching micro-session to your next enablement sprint.',
+        source: 'Enablement Weekly',
+        time: 'Just now',
+        metric: 'Mastery · 91',
+        tags: ['Learning journey', 'Peer coaching'],
+        score: 91
+      },
+      {
+        title: 'From content libraries to skill ecosystems',
+        summary:
+          'LaunchPad replaced static content with adaptive pathways triggered by live performance data.',
+        insight:
+          'Serve the right practice challenge the moment someone needs it.',
+        action: 'Review your triggers—do they signal when someone needs a new challenge?',
+        source: 'Skill Graph Dispatch',
+        time: '2h ago',
+        metric: 'Relevance · 87',
+        tags: ['Enablement tech', 'Adaptive pathways'],
+        score: 87
+      },
+      {
+        title: 'Micro-coaching that scales empathy',
+        summary:
+          'Brightside Sales introduced 5-minute audio reflections that managers respond to with voice notes.',
+        insight:
+          'Short, human responses beat scripted feedback for building trust.',
+        action: 'Record a voice note response instead of typing your next coaching update.',
+        source: 'Learning Leaders Lab',
+        time: 'Yesterday',
+        metric: 'Trust · 83',
+        tags: ['Coaching', 'Enablement culture'],
+        score: 83
+      }
+    ],
+    momentum: [
+      {
+        title: 'Map the learner journey',
+        detail: 'Identify the signature practice moment that cements the skill.',
+        energy: '+5 mastery'
+      },
+      {
+        title: 'Trigger adaptive support',
+        detail: 'Set a signal that prompts coaching when performance dips.',
+        energy: '+3 responsiveness'
+      },
+      {
+        title: 'Celebrate story wins',
+        detail: 'Collect and share one learner story in your next enablement newsletter.',
+        energy: '+4 motivation'
+      }
+    ],
+    intros: [
+      {
+        name: 'Shreya Patel',
+        role: 'Head of Enablement · Elevate Academy',
+        reason: 'Pairs practice arenas with peer coaching to drive mastery.'
+      },
+      {
+        name: 'Louis Carter',
+        role: 'Learning Architect · LaunchPad',
+        reason: 'Builds adaptive pathways triggered by performance data.'
+      },
+      {
+        name: 'Adele Grant',
+        role: 'Enablement Coach · Brightside Sales',
+        reason: 'Humanizes coaching with quick voice note reflections.'
+      }
+    ],
+    opportunities: [
+      {
+        title: 'Adaptive pathway strategist',
+        detail: 'Help a growth-stage startup personalize onboarding through data-driven triggers.'
+      },
+      {
+        title: 'Peer coaching community builder',
+        detail: 'Design story-sharing rituals across a distributed enablement team.'
+      },
+      {
+        title: 'Learning analytics translator',
+        detail: 'Turn enablement dashboards into action plans managers actually use.'
+      }
+    ],
+    learning: [
+      {
+        title: 'Practice arena design sprint',
+        detail: 'Prototype simulations that feel real while staying safe to learn.'
+      },
+      {
+        title: 'Micro-coaching audio lab',
+        detail: 'Experiment with human voice formats that scale empathetic feedback.'
+      },
+      {
+        title: 'Enablement analytics clinic',
+        detail: 'Translate performance signals into personalized learning nudges.'
+      }
+    ]
+  }
+};
+
+const personalityProfiles = {
+  INFJ: {
+    headline: 'Lead with meaningful foresight.',
+    description:
+      'You seek purpose-driven collaboration and thrive when conversations dig below the obvious to reveal hidden patterns.',
+    energy: 'Energized by purposeful 1:1s and reflective strategy jams.',
+    strengths: [
+      'Translate complexity into human stories',
+      'Spot subtle tensions before they surface',
+      'Coach people toward values-aligned action'
+    ],
+    progressCue:
+      'Share one “why this matters” insight with your network this week to magnetize allies.',
+    compatibility: [
+      {
+        type: 'ENTP',
+        dynamic: 'They challenge your visions with playful debate, helping you pressure-test bold ideas.',
+        move: 'Trade quick voice memos outlining wild scenarios, then co-map the most energizing path.'
+      },
+      {
+        type: 'INTJ',
+        dynamic: 'Their structured thinking helps your intuition land in executable roadmaps.',
+        move: 'Co-create a future-back plan pairing your narrative with their milestone rigor.'
+      },
+      {
+        type: 'ENFP',
+        dynamic: 'They amplify your meaning-making with contagious enthusiasm.',
+        move: 'Schedule a creative jam focused on the impact stories that most light you both up.'
+      }
+    ],
+    conversationPrompts: [
+      '“What future are we quietly building—and how do we invite others into it?”',
+      '“Whose voice is missing from this decision, and how can we surface it with care?”',
+      '“Which small ritual would restore purpose for our team this week?”'
+    ],
+    energyReset: 'Block 15 minutes after intense collaborations to journal the insights you sensed.',
+    collaborationTip:
+      'Open meetings by naming the purpose and desired feeling—people will follow your clarity.'
+  },
+  ENTP: {
+    headline: 'Ignite the room with possibility.',
+    description:
+      'You love challenging assumptions, spinning up experiments, and inspiring others to imagine bold futures.',
+    energy: 'Fueled by fast-paced brainstorms and clever debate.',
+    strengths: [
+      'Connect seemingly unrelated ideas',
+      'Spark experimentation through humor and wit',
+      'See strategic openings others miss'
+    ],
+    progressCue:
+      'Ship one tiny experiment every week so your ideas don’t stay hypothetical.',
+    compatibility: [
+      {
+        type: 'INFJ',
+        dynamic: 'They anchor your ideas in purpose, ensuring the change you spark feels meaningful.',
+        move: 'Let them frame the impact story before you riff on creative routes.'
+      },
+      {
+        type: 'INTJ',
+        dynamic: 'Their disciplined execution keeps your experiments on track.',
+        move: 'Invite them to outline the success metrics for your next wild idea.'
+      },
+      {
+        type: 'ENFP',
+        dynamic: 'Together you magnetize communities with optimistic storytelling.',
+        move: 'Co-host a live jam session to crowdsource playful solutions.'
+      }
+    ],
+    conversationPrompts: [
+      '“Which assumption should we break next to unlock momentum?”',
+      '“How might we turn this into a rapid experiment people want to join?”',
+      '“Who can we invite to remix this idea with us?”'
+    ],
+    energyReset: 'Take a 10-minute curiosity walk—capture voice notes of surprising connections you spot.',
+    collaborationTip: 'Balance spontaneity with short debriefs so the team captures the learnings you sparked.'
+  },
+  INTJ: {
+    headline: 'Architect systems that accelerate progress.',
+    description:
+      'You see the long arc of strategy and build frameworks that guide teams toward the future with precision.',
+    energy: 'Energized by deep focus, well-structured debates, and measurable outcomes.',
+    strengths: [
+      'Design future-back roadmaps',
+      'Translate vision into execution plans',
+      'Anticipate obstacles before they derail momentum'
+    ],
+    progressCue:
+      'Share your next milestone map with a trusted partner for feedback before locking it in.',
+    compatibility: [
+      {
+        type: 'INFJ',
+        dynamic: 'They inject mission and humanity into your plans, rallying hearts and minds.',
+        move: 'Invite them to craft the story arc that accompanies your roadmap.'
+      },
+      {
+        type: 'ENTP',
+        dynamic: 'They keep you iterating by pressure-testing assumptions playfully.',
+        move: 'Run a structured debate to validate the riskiest part of your plan.'
+      },
+      {
+        type: 'ENFP',
+        dynamic: 'They ensure the humans impacted stay centered in your system design.',
+        move: 'Ask them to lead user story interviews that feed your strategy.'
+      }
+    ],
+    conversationPrompts: [
+      '“What constraint, if removed, would speed up this roadmap?”',
+      '“Where do we need more signal before committing resources?”',
+      '“Which allies should we bring in early to ensure adoption?”'
+    ],
+    energyReset: 'Block maker time on your calendar and protect it fiercely—deep work fuels your clarity.',
+    collaborationTip: 'Share the decision criteria you are using so collaborators can contribute data that matters.'
+  },
+  ENFP: {
+    headline: 'Connect people to bold possibilities.',
+    description:
+      'You thrive when ideas spark human connection and teams rally around shared purpose.',
+    energy: 'Fueled by collaborative jams, values-driven storytelling, and spontaneous exploration.',
+    strengths: [
+      'Spot potential in people and projects',
+      'Galvanize teams with energizing stories',
+      'Bridge communities through authentic relationships'
+    ],
+    progressCue:
+      'Host one gathering this week where people leave with a new connection or idea to pursue.',
+    compatibility: [
+      {
+        type: 'INFJ',
+        dynamic: 'They help you deepen meaning and sustain momentum beyond the spark.',
+        move: 'Co-design a ritual that keeps the purpose visible after the brainstorm.'
+      },
+      {
+        type: 'ENTP',
+        dynamic: 'Together you generate a whirlwind of imaginative experiments.',
+        move: 'Pair-share: you source the people, they design the challenge.'
+      },
+      {
+        type: 'INTJ',
+        dynamic: 'They provide the scaffolding that keeps your ideas moving toward launch.',
+        move: 'Invite them to translate your community buzz into a staged rollout plan.'
+      }
+    ],
+    conversationPrompts: [
+      '“Who else needs to be in this conversation so it becomes a movement?”',
+      '“What story would light up the people we hope to invite?”',
+      '“How can we make the first step irresistible?”'
+    ],
+    energyReset: 'Schedule a quiet creative refill—journal, collage, or walk somewhere inspiring alone.',
+    collaborationTip: 'Share quick voice memos to keep energy high between meetings and celebrate tiny wins.'
+  }
+};
+
+const defaultInterests = [
+  'AI Product Strategy',
+  'Future of Work Evolution',
+  'Community Design & Belonging'
+];
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderInterestOptions();
+  bindEvents();
+  updateAll();
+  const personalitySelect = document.getElementById('personalityType');
+  updatePersonality(personalitySelect.value);
+});
+
+function bindEvents() {
+  const generateButton = document.getElementById('generateButton');
+  generateButton.addEventListener('click', updateAll);
+  const personalitySelect = document.getElementById('personalityType');
+  personalitySelect.addEventListener('change', (event) => {
+    updatePersonality(event.target.value);
+  });
+}
+
+function renderInterestOptions() {
+  const selector = document.getElementById('interestSelector');
+  selector.innerHTML = '';
+  Object.entries(interestProfiles).forEach(([interest, profile]) => {
+    const optionId = `interest-${interest.replace(/[^a-z0-9]/gi, '-').toLowerCase()}`;
+    const label = document.createElement('label');
+    label.className = 'interest-option';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.name = 'interest';
+    input.id = optionId;
+    input.value = interest;
+    if (defaultInterests.includes(interest)) {
+      input.checked = true;
+      label.classList.add('active');
+    }
+
+    const content = document.createElement('div');
+    content.className = 'interest-option-content';
+    const title = document.createElement('span');
+    title.className = 'interest-title';
+    title.textContent = interest;
+    const caption = document.createElement('span');
+    caption.className = 'interest-caption';
+    caption.textContent = profile.description;
+
+    content.append(title, caption);
+    label.append(input, content);
+    selector.appendChild(label);
+
+    label.addEventListener('click', (event) => {
+      if (event.target.tagName !== 'INPUT') {
+        input.checked = !input.checked;
+      }
+      label.classList.toggle('active', input.checked);
+      updateAll();
+    });
+
+    input.addEventListener('change', () => {
+      label.classList.toggle('active', input.checked);
+      updateAll();
+    });
+  });
+}
+
+function updateAll() {
+  const selectedInterests = getSelectedInterests();
+  const curatedCount = renderFeed(selectedInterests);
+  renderActiveInterests(selectedInterests);
+  renderMomentumList(selectedInterests);
+  renderIntroductions(selectedInterests);
+  renderOpportunities(selectedInterests);
+  renderLearning(selectedInterests);
+  renderInsightPills(selectedInterests);
+  updateInsightBanner(selectedInterests, curatedCount);
+  updateProfileMetrics(selectedInterests);
+}
+
+function getSelectedInterests() {
+  return Array.from(
+    document.querySelectorAll('input[name="interest"]:checked'),
+    (checkbox) => checkbox.value
+  );
+}
+
+function renderActiveInterests(selectedInterests) {
+  const container = document.getElementById('activeInterests');
+  container.innerHTML = '';
+  if (!selectedInterests.length) {
+    const message = document.createElement('span');
+    message.textContent = 'No interests selected yet—choose a few to unlock insights!';
+    container.appendChild(message);
+    return;
+  }
+
+  selectedInterests.forEach((interest) => {
+    const chip = document.createElement('span');
+    chip.className = 'chip';
+    chip.textContent = interest;
+    container.appendChild(chip);
+  });
+}
+
+function renderFeed(selectedInterests) {
+  const container = document.getElementById('feedContainer');
+  container.innerHTML = '';
+  if (!selectedInterests.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-feed';
+    empty.innerHTML = `
+      <p>Your feed is waiting for direction.</p>
+      <span>Select interests to generate stories, opportunities, and rituals tailored to you.</span>
+    `;
+    container.appendChild(empty);
+    return 0;
+  }
+
+  const entries = [];
+  selectedInterests.forEach((interest) => {
+    const profile = interestProfiles[interest];
+    if (!profile) return;
+    profile.feed.forEach((item) => {
+      entries.push({ ...item, interest });
+    });
+  });
+
+  if (!entries.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-feed';
+    empty.innerHTML = `
+      <p>No stories yet.</p>
+      <span>Try selecting a different combination of interests to spark new signals.</span>
+    `;
+    container.appendChild(empty);
+    return 0;
+  }
+
+  const sorted = entries.sort((a, b) => b.score - a.score);
+  sorted.forEach((entry) => {
+    const article = document.createElement('article');
+    article.className = 'feed-card';
+
+    const meta = document.createElement('div');
+    meta.className = 'feed-meta';
+
+    const metaInfo = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = entry.title;
+    const source = document.createElement('span');
+    source.textContent = `${entry.source} · ${entry.time}`;
+    metaInfo.append(title, source);
+
+    const badge = document.createElement('span');
+    badge.className = 'badge';
+    badge.textContent = `${entry.metric}`;
+
+    meta.append(metaInfo, badge);
+
+    const body = document.createElement('p');
+    body.className = 'feed-body';
+    body.textContent = entry.summary;
+
+    const insight = document.createElement('p');
+    insight.className = 'feed-insight';
+    insight.textContent = entry.insight;
+
+    const action = document.createElement('div');
+    action.className = 'feed-actions';
+
+    const actionButton = document.createElement('button');
+    actionButton.type = 'button';
+    actionButton.textContent = entry.action;
+
+    const connectButton = document.createElement('button');
+    connectButton.type = 'button';
+    connectButton.textContent = 'Save to playbook';
+
+    action.append(actionButton, connectButton);
+
+    const tags = document.createElement('div');
+    tags.className = 'feed-tags';
+    tags.appendChild(createChip(interest));
+    entry.tags.forEach((tag) => {
+      tags.appendChild(createChip(tag));
+    });
+
+    article.append(meta, body, insight, action, tags);
+    container.appendChild(article);
+  });
+
+  return sorted.length;
+}
+
+function createChip(label) {
+  const chip = document.createElement('span');
+  chip.className = 'chip';
+  chip.textContent = label;
+  return chip;
+}
+
+function renderMomentumList(selectedInterests) {
+  const list = document.getElementById('momentumList');
+  list.innerHTML = '';
+  const tasks = [];
+  selectedInterests.forEach((interest) => {
+    const profile = interestProfiles[interest];
+    profile?.momentum.forEach((task) => tasks.push({ ...task, interest }));
+  });
+
+  if (!tasks.length) {
+    const item = document.createElement('li');
+    item.className = 'list-item';
+    const title = document.createElement('strong');
+    title.textContent = 'Choose focus areas';
+    const detail = document.createElement('span');
+    detail.textContent = 'Selecting interests will unlock momentum rituals tailored to your goals.';
+    item.append(title, detail);
+    list.appendChild(item);
+    return;
+  }
+
+  tasks
+    .slice(0, 4)
+    .forEach(({ title, detail, energy, interest }) => {
+      const item = document.createElement('li');
+      item.className = 'list-item';
+      const titleEl = document.createElement('strong');
+      titleEl.textContent = `${title}`;
+      const detailEl = document.createElement('span');
+      detailEl.textContent = detail;
+      const energyEl = document.createElement('span');
+      energyEl.className = 'chip';
+      energyEl.textContent = `${interest} · ${energy}`;
+      item.append(titleEl, detailEl, energyEl);
+      list.appendChild(item);
+    });
+}
+
+function renderIntroductions(selectedInterests) {
+  const list = document.getElementById('introList');
+  list.innerHTML = '';
+  const suggestions = [];
+  selectedInterests.forEach((interest) => {
+    const profile = interestProfiles[interest];
+    profile?.intros.forEach((intro) => suggestions.push({ ...intro, interest }));
+  });
+
+  if (!suggestions.length) {
+    list.appendChild(createListPlaceholder('Activate introductions by selecting interests.'));
+    return;
+  }
+
+  suggestions.slice(0, 4).forEach(({ name, role, reason, interest }) => {
+    const item = document.createElement('li');
+    item.className = 'list-item';
+    const title = document.createElement('strong');
+    title.textContent = `${name} · ${interest}`;
+    const subtitle = document.createElement('span');
+    subtitle.textContent = role;
+    const detail = document.createElement('p');
+    detail.textContent = reason;
+    item.append(title, subtitle, detail);
+    list.appendChild(item);
+  });
+}
+
+function renderOpportunities(selectedInterests) {
+  const list = document.getElementById('opportunityList');
+  list.innerHTML = '';
+  const items = [];
+  selectedInterests.forEach((interest) => {
+    const profile = interestProfiles[interest];
+    profile?.opportunities.forEach((op) => items.push({ ...op, interest }));
+  });
+
+  if (!items.length) {
+    list.appendChild(createListPlaceholder('Select interests to uncover curated opportunities.'));
+    return;
+  }
+
+  items.slice(0, 4).forEach(({ title, detail, interest }) => {
+    const item = document.createElement('li');
+    item.className = 'list-item';
+    const titleEl = document.createElement('strong');
+    titleEl.textContent = `${title}`;
+    const detailEl = document.createElement('p');
+    detailEl.textContent = `${detail} (${interest})`;
+    item.append(titleEl, detailEl);
+    list.appendChild(item);
+  });
+}
+
+function renderLearning(selectedInterests) {
+  const list = document.getElementById('learningList');
+  list.innerHTML = '';
+  const items = [];
+  selectedInterests.forEach((interest) => {
+    const profile = interestProfiles[interest];
+    profile?.learning.forEach((resource) => items.push({ ...resource, interest }));
+  });
+
+  if (!items.length) {
+    list.appendChild(createListPlaceholder('Curated learning tracks appear once you select interests.'));
+    return;
+  }
+
+  items.slice(0, 4).forEach(({ title, detail, interest }) => {
+    const item = document.createElement('li');
+    item.className = 'list-item';
+    const titleEl = document.createElement('strong');
+    titleEl.textContent = title;
+    const detailEl = document.createElement('p');
+    detailEl.textContent = `${detail} (${interest})`;
+    item.append(titleEl, detailEl);
+    list.appendChild(item);
+  });
+}
+
+function renderInsightPills(selectedInterests) {
+  const pillContainer = document.getElementById('insightPills');
+  pillContainer.innerHTML = '';
+  const highlights = new Set();
+  selectedInterests.forEach((interest) => {
+    const profile = interestProfiles[interest];
+    profile?.highlights.forEach((highlight) => highlights.add(highlight));
+  });
+
+  if (!highlights.size) {
+    const pill = document.createElement('span');
+    pill.className = 'insight-pill';
+    pill.textContent = 'Select interests to unlock signals';
+    pillContainer.appendChild(pill);
+    return;
+  }
+
+  Array.from(highlights)
+    .slice(0, 6)
+    .forEach((highlight) => {
+      const pill = document.createElement('span');
+      pill.className = 'insight-pill';
+      pill.textContent = highlight;
+      pillContainer.appendChild(pill);
+    });
+}
+
+function updateInsightBanner(selectedInterests, curatedCount) {
+  const bannerText = document.querySelector('#insightBanner p');
+  if (!bannerText) return;
+  if (!selectedInterests.length) {
+    bannerText.textContent =
+      'PersonaGraph synthesizes career stories, learning paths, and opportunities across your chosen interests.';
+    return;
+  }
+
+  const lanes = selectedInterests.length;
+  bannerText.textContent = `Serving ${lanes} focus lane${lanes > 1 ? 's' : ''} with ${curatedCount} fresh signals.`;
+}
+
+function updateProfileMetrics(selectedInterests) {
+  const connectionCount = document.getElementById('connectionCount');
+  const collaborationScore = document.getElementById('collaborationScore');
+  if (!connectionCount || !collaborationScore) return;
+  const baseConnections = 128;
+  const baseCollaboration = 87;
+  connectionCount.textContent = baseConnections + selectedInterests.length * 4;
+  const momentumBoost = selectedInterests.reduce((total, interest) => {
+    const profile = interestProfiles[interest];
+    return total + (profile?.momentum.length || 0);
+  }, 0);
+  collaborationScore.textContent = baseCollaboration + Math.min(10, momentumBoost);
+}
+
+function createListPlaceholder(message) {
+  const item = document.createElement('li');
+  item.className = 'list-item';
+  const detail = document.createElement('span');
+  detail.textContent = message;
+  item.appendChild(detail);
+  return item;
+}
+
+function updatePersonality(type) {
+  const profile = personalityProfiles[type];
+  if (!profile) return;
+  const overview = document.getElementById('personalityOverview');
+  const compatibilityPanel = document.getElementById('compatibilityPanel');
+  const conversationPanel = document.getElementById('conversationPanel');
+
+  overview.innerHTML = `
+    <h3>${profile.headline}</h3>
+    <p>${profile.description}</p>
+    <div class="badge">${profile.energy}</div>
+    <h4>Superpowers</h4>
+    <ul>${profile.strengths.map((item) => `<li>${item}</li>`).join('')}</ul>
+    <div class="conversation-prompt">${profile.progressCue}</div>
+    <p class="microcopy">${profile.collaborationTip}</p>
+  `;
+
+  compatibilityPanel.innerHTML = `
+    <h3>Collaboration chemistry</h3>
+    <div class="compatibility-grid">
+      ${profile.compatibility
+        .map(
+          (match) => `
+            <div class="compatibility-card">
+              <strong>${match.type}</strong>
+              <p>${match.dynamic}</p>
+              <span>${match.move}</span>
+            </div>
+          `
+        )
+        .join('')}
+    </div>
+  `;
+
+  conversationPanel.innerHTML = `
+    <h3>Conversation catalysts</h3>
+    <ul>${profile.conversationPrompts.map((prompt) => `<li>${prompt}</li>`).join('')}</ul>
+    <div class="conversation-prompt">Energy reset: ${profile.energyReset}</div>
+  `;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PersonaGraph | Interest-Aware Network</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <noscript>
+      <div class="noscript-warning">
+        PersonaGraph works best with JavaScript enabled. Please enable it to
+        generate adaptive content based on your interests.
+      </div>
+    </noscript>
+
+    <header class="top-nav">
+      <div class="brand">
+        <span class="brand-icon">PG</span>
+        <div>
+          <h1>PersonaGraph</h1>
+          <p class="brand-tagline">Curated knowledge for your evolving goals</p>
+        </div>
+      </div>
+      <div class="search-bar">
+        <input
+          type="search"
+          id="search"
+          placeholder="Search people, opportunities, or resources"
+          aria-label="Search PersonaGraph"
+        />
+      </div>
+      <nav class="nav-actions" aria-label="Primary">
+        <button type="button" class="nav-button" aria-label="Home feed">
+          <span>Home</span>
+        </button>
+        <button type="button" class="nav-button" aria-label="Network">
+          <span>Network</span>
+        </button>
+        <button type="button" class="nav-button" aria-label="Opportunities">
+          <span>Opportunities</span>
+        </button>
+        <button type="button" class="nav-button" aria-label="Messages">
+          <span>Messages</span>
+        </button>
+      </nav>
+    </header>
+
+    <main class="layout">
+      <aside class="sidebar" aria-label="Profile and interest controls">
+        <section class="card profile-card">
+          <div class="profile-banner"></div>
+          <div class="profile-content">
+            <div class="avatar" aria-hidden="true">AL</div>
+            <h2>Alex Lane</h2>
+            <p class="profile-title">Product strategist · Community catalyst</p>
+            <ul class="profile-metrics">
+              <li><strong id="connectionCount">128</strong> connections</li>
+              <li><strong id="collaborationScore">87</strong> collaboration index</li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="card interest-card">
+          <header>
+            <h2>Shape your feed</h2>
+            <p>Select topics to generate your daily insight stream.</p>
+          </header>
+          <form id="interestForm">
+            <fieldset>
+              <legend class="sr-only">Choose interests</legend>
+              <div id="interestSelector" class="interest-selector"></div>
+            </fieldset>
+            <button type="button" id="generateButton" class="primary-button">
+              Refresh recommendations
+            </button>
+          </form>
+          <div class="active-interests" id="activeInterests" aria-live="polite"></div>
+        </section>
+
+        <section class="card cadence-card">
+          <h2>Momentum planner</h2>
+          <ul class="momentum-list" id="momentumList"></ul>
+        </section>
+      </aside>
+
+      <section class="main-feed" aria-label="Personalized feed">
+        <section class="card post-composer">
+          <h2>Share something meaningful today</h2>
+          <textarea
+            id="statusComposer"
+            rows="3"
+            placeholder="Start a conversation that energizes your network"
+            aria-label="Share an update"
+          ></textarea>
+          <div class="composer-actions">
+            <div class="chip-row">
+              <span class="chip">Idea</span>
+              <span class="chip">Opportunity</span>
+              <span class="chip">Question</span>
+            </div>
+            <button type="button" class="secondary-button">Save draft</button>
+            <button type="button" class="primary-button">Share</button>
+          </div>
+        </section>
+
+        <section class="card insight-banner" id="insightBanner">
+          <div>
+            <h2>Adaptive insight stream</h2>
+            <p>
+              PersonaGraph synthesizes career stories, learning paths, and
+              opportunities across your chosen interests.
+            </p>
+          </div>
+          <div class="insight-pills" id="insightPills"></div>
+        </section>
+
+        <div id="feedContainer" class="feed-container" aria-live="polite"></div>
+      </section>
+
+      <aside class="sidebar" aria-label="Highlights and opportunities">
+        <section class="card">
+          <h2>Quick introductions</h2>
+          <ul class="intro-list" id="introList"></ul>
+        </section>
+        <section class="card">
+          <h2>Opportunity radar</h2>
+          <ul class="opportunity-list" id="opportunityList"></ul>
+        </section>
+        <section class="card">
+          <h2>Learning spotlight</h2>
+          <ul class="learning-list" id="learningList"></ul>
+        </section>
+      </aside>
+    </main>
+
+    <section class="personality-hub" aria-labelledby="personalityHeading">
+      <div class="personality-header">
+        <div>
+          <h2 id="personalityHeading">Personality resonance hub</h2>
+          <p>
+            Tune how PersonaGraph communicates with you and your collaborators by
+            selecting an interaction style.
+          </p>
+        </div>
+        <div class="personality-select">
+          <label for="personalityType">Choose a personality lens</label>
+          <select id="personalityType" name="personalityType">
+            <option value="INFJ">INFJ · The Insightful Advocate</option>
+            <option value="ENTP">ENTP · The Visionary Challenger</option>
+            <option value="INTJ">INTJ · The Strategic Architect</option>
+            <option value="ENFP">ENFP · The Imaginative Connector</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="personality-grid">
+        <section class="card personality-card" id="personalityOverview"></section>
+        <section class="card personality-card" id="compatibilityPanel"></section>
+        <section class="card personality-card" id="conversationPanel"></section>
+      </div>
+    </section>
+
+    <footer class="app-footer">
+      <div>
+        <strong>PersonaGraph Labs</strong>
+        <p>Designed to help multi-dimensional people create meaningful work.</p>
+      </div>
+      <div class="footer-links">
+        <a href="#">About</a>
+        <a href="#">Guiding principles</a>
+        <a href="#">Privacy</a>
+        <a href="#">Accessibility</a>
+      </div>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,672 @@
+:root {
+  --background: #f4f5f7;
+  --surface: #ffffff;
+  --accent: #3b82f6;
+  --accent-soft: #dbeafe;
+  --text-primary: #1f2933;
+  --text-secondary: #52606d;
+  --text-tertiary: #9aa5b1;
+  --border: #d9e2ec;
+  --shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+  --radius: 16px;
+  --radius-sm: 10px;
+  --radius-lg: 24px;
+  --transition: 180ms ease-in-out;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text-primary);
+  font-family: inherit;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+h1,
+ h2,
+ h3,
+ h4 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+h4 {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+ a:focus {
+  text-decoration: underline;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.noscript-warning {
+  background: #f59e0b;
+  color: #1f2937;
+  padding: 0.75rem 1.5rem;
+  text-align: center;
+}
+
+.top-nav {
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 2.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-icon {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #3b82f6, #14b8a6);
+  color: white;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.brand h1 {
+  font-size: 1.2rem;
+}
+
+.brand-tagline {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}
+
+.search-bar {
+  flex: 0.8;
+  display: flex;
+  justify-content: center;
+}
+
+.search-bar input {
+  width: min(520px, 100%);
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 0.65rem 1.1rem;
+  font-size: 0.95rem;
+  background: #f8fafc;
+}
+
+.nav-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.nav-button {
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  padding: 0.55rem 0.95rem;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.nav-button:hover,
+ .nav-button:focus {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 310px;
+  gap: 1.5rem;
+  padding: 1.5rem 2.5rem 3rem;
+  flex: 1 1 auto;
+}
+
+.sidebar {
+  display: grid;
+  gap: 1.2rem;
+  align-content: start;
+}
+
+.main-feed {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: 0 18px 28px rgba(15, 23, 42, 0.05);
+  padding: 1.3rem 1.4rem;
+}
+
+.profile-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.profile-banner {
+  height: 82px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.45), rgba(20, 184, 166, 0.5));
+}
+
+.profile-content {
+  padding: 1.2rem 1.4rem 1.5rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.avatar {
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 1.1rem;
+  margin-top: -3.2rem;
+  border: 4px solid var(--surface);
+}
+
+.profile-title {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+}
+
+.profile-metrics {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.3rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.interest-card header {
+  display: grid;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.interest-selector {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.interest-option {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+}
+
+.interest-option-content {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.interest-title {
+  font-weight: 600;
+}
+
+.interest-caption {
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+  line-height: 1.35;
+}
+
+.interest-option input {
+  accent-color: var(--accent);
+}
+
+.interest-option.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.active-interests {
+  margin-top: 0.9rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-height: 32px;
+}
+
+.active-interests .chip {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--accent);
+}
+
+.primary-button,
+.secondary-button {
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #2563eb, #14b8a6);
+  color: white;
+  box-shadow: 0 12px 18px rgba(37, 99, 235, 0.25);
+}
+
+.primary-button:hover,
+.primary-button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 24px rgba(37, 99, 235, 0.2);
+}
+
+.secondary-button {
+  background: rgba(79, 70, 229, 0.08);
+  color: #4338ca;
+}
+
+.secondary-button:hover,
+.secondary-button:focus {
+  transform: translateY(-1px);
+}
+
+.post-composer textarea {
+  width: 100%;
+  resize: vertical;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  padding: 0.8rem 1rem;
+  font-size: 0.95rem;
+  min-height: 100px;
+  background: #f8fafc;
+}
+
+.composer-actions {
+  margin-top: 0.9rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.chip-row {
+  margin-right: auto;
+  display: flex;
+  gap: 0.45rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text-secondary);
+}
+
+.insight-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.08), rgba(20, 184, 166, 0.08));
+}
+
+.insight-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  justify-content: flex-end;
+}
+
+.insight-pill {
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  font-size: 0.75rem;
+  color: #1d4ed8;
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.feed-container {
+  display: grid;
+  gap: 1rem;
+}
+
+.empty-feed {
+  padding: 2rem 2.2rem;
+  border-radius: var(--radius);
+  background: rgba(148, 163, 184, 0.15);
+  display: grid;
+  gap: 0.6rem;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.empty-feed span {
+  color: var(--text-tertiary);
+}
+
+.feed-card {
+  border-radius: var(--radius);
+  border: 1px solid rgba(15, 23, 42, 0.04);
+  padding: 1.2rem 1.4rem;
+  background: var(--surface);
+  box-shadow: 0 18px 25px rgba(15, 23, 42, 0.04);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.feed-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.feed-meta strong {
+  font-size: 1.05rem;
+}
+
+.feed-meta span {
+  color: var(--text-tertiary);
+  font-size: 0.85rem;
+}
+
+.feed-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.feed-tags .chip {
+  background: rgba(20, 184, 166, 0.12);
+  color: #0f766e;
+}
+
+.feed-body {
+  font-size: 0.98rem;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+.feed-insight {
+  padding: 0.75rem 0.9rem;
+  border-left: 3px solid rgba(59, 130, 246, 0.55);
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #1d4ed8;
+}
+
+.feed-actions {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.feed-actions button {
+  border: none;
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.feed-actions button:hover,
+.feed-actions button:focus {
+  background: rgba(59, 130, 246, 0.16);
+}
+
+.intro-list,
+.opportunity-list,
+.learning-list,
+.momentum-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.list-item {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.list-item strong {
+  font-size: 0.92rem;
+}
+
+.list-item span {
+  font-size: 0.82rem;
+  color: var(--text-tertiary);
+}
+
+.personality-hub {
+  margin: 0 2.5rem 3rem;
+  padding: 2.2rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.12), rgba(236, 72, 153, 0.1));
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: 0 28px 45px rgba(15, 23, 42, 0.09);
+}
+
+.personality-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
+
+.personality-select {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.personality-select select {
+  border-radius: 12px;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  min-width: 260px;
+}
+
+.personality-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.2rem;
+}
+
+.personality-card {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.8rem;
+}
+
+.personality-card h3 {
+  font-size: 1.05rem;
+}
+
+.personality-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.badge {
+  display: inline-flex;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.compatibility-grid {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.compatibility-card {
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.compatibility-card strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.compatibility-card span {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.conversation-prompt {
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: rgba(236, 72, 153, 0.08);
+  border: 1px solid rgba(236, 72, 153, 0.2);
+}
+
+.microcopy {
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+}
+
+.app-footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  padding: 1.5rem 2.5rem 2rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+}
+
+@media (max-width: 1180px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr) 310px;
+  }
+
+  .sidebar:first-of-type {
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  }
+
+  .sidebar:first-of-type .card {
+    height: 100%;
+  }
+}
+
+@media (max-width: 920px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar,
+  .main-feed {
+    grid-column: 1 / -1;
+  }
+
+  .app-footer {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .personality-hub {
+    margin: 0 1.5rem 2rem;
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 680px) {
+  .top-nav {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem 1.2rem;
+  }
+
+  .brand {
+    justify-content: center;
+  }
+
+  .search-bar {
+    width: 100%;
+  }
+
+  .nav-actions {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .layout {
+    padding: 1rem 1.2rem 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add PersonaGraph landing page with profile, feed, and interest selection controls
- style the experience with a social-network inspired layout and responsive adjustments
- implement client-side data generation for interest feeds, sidebars, and personality resonance hub

## Testing
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68cb028877cc832fac5336d9a1ea55af